### PR TITLE
1. Add the initial web server

### DIFF
--- a/web_server.rb
+++ b/web_server.rb
@@ -1,0 +1,29 @@
+require 'socket'
+
+class WebServer
+  HOST = '127.0.0.1'
+  PORT = 8000
+  MAX_REQUEST_SIZE = 1024
+
+  def serve
+    # Create a new TCPServer bound to our computer on port 8000
+    # This will make it accessible in the browser at http://127.0.0.1:8000
+    # It _won't_ yet respond with a valid message, so the browser will
+    # likely show an error message when we visit it.
+    server = TCPServer.new HOST, PORT
+    puts "[INFO] Accepting connections at http://#{HOST}:#{PORT}"
+    puts '[INFO] Exit this program with CTRL-C'
+
+    # This server will loop forever until you kill it with CTRL-C
+    # Each pass through the loop will accept 1 web request, print
+    # it out, and then close the request.
+    loop do
+      connection = server.accept
+      request = connection.recv MAX_REQUEST_SIZE
+      puts request
+      connection.close
+    end
+  end
+end
+
+WebServer.new.serve


### PR DESCRIPTION
At this point, all our web server can do is accept new requests and print them out. It doesn't respond with valid HTTP so although we can visit it in the browser (and see the request in our terminal) we won't actually get a response back yet.

We're making use of [Socket](https://ruby-doc.org/stdlib-2.5.3/libdoc/socket/rdoc/Socket.html) from Ruby's standard library in order to accept network connections on the computer. There are more customizable low-level ways of opening a socket in Ruby, but we're opting for the simplest here.

This web server has a number of limitations: in addition to not actually returning any HTTP yet, it can only accept the first 1024 bytes of a request, is hardcoded to list on `127.0.0.1:8000` and can only accept the one request at a time. We'll get to that.

Up next, we'll evolve this web server into something that can send a proper "Hello World" response.