### PR TITLE
2. Configure our web server to send a proper response

### DIFF
--- a/web_server.rb
+++ b/web_server.rb
@@ -5,22 +5,46 @@ class WebServer
   PORT = 8000
   MAX_REQUEST_SIZE = 1024
 
+  def initialize
+    @server = TCPServer.new HOST, PORT
+  end
+
+  # Our response must comply with the HTTP Spec
+  # https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html
+  #
+  # This says that our first line, the "status line", should consist
+  # of the HTTP version number, followed by the status code.
+  #
+  # Subsequent lines are (optional) header lines, with the key and
+  # value separated by a colon.
+  #
+  # After the headers, there comes a single blank line as a delimeter.
+  #
+  # After that, comes the body of the message itself.
+  #
+  # Most browsers will simply print this body out if it is text,
+  # which is what we use in this example. HTML and other formats can
+  # also be used here by setting the appropriate Content-Type header.
+  def response
+    response_body = 'Hello World!'
+    <<~EOF
+      HTTP/1.1 200 OK
+      Content-Type: text/html
+      Content-Length: #{response_body.length}
+
+      #{response_body}
+    EOF
+  end
+
   def serve
-    # Create a new TCPServer bound to our computer on port 8000
-    # This will make it accessible in the browser at http://127.0.0.1:8000
-    # It _won't_ yet respond with a valid message, so the browser will
-    # likely show an error message when we visit it.
-    server = TCPServer.new HOST, PORT
     puts "[INFO] Accepting connections at http://#{HOST}:#{PORT}"
     puts '[INFO] Exit this program with CTRL-C'
 
-    # This server will loop forever until you kill it with CTRL-C
-    # Each pass through the loop will accept 1 web request, print
-    # it out, and then close the request.
     loop do
-      connection = server.accept
+      connection = @server.accept
       request = connection.recv MAX_REQUEST_SIZE
       puts request
+      connection.puts response
       connection.close
     end
   end


### PR DESCRIPTION
Now that our server is able to accept connections, we have to teach it to speak HTTP. The specification for HTTP sets out a definition for responses in https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html

It defines a response like so:

```
       Response      = Status-Line
                       *(( general-header
                        | response-header
                        | entity-header ) CRLF)
                       CRLF
                       [ message-body ]

       Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
```

The first line is always a status line, and looks like this: "HTTP/1.1 200 OK"
Following that are some (optional) header lines of the form "Example-Header: some-kinda-value"
Then there's a blank line (or "[CRLF](https://developer.mozilla.org/en-US/docs/Glossary/CRLF)") between the headers and the message body itself.

We're going to respond with a simple "Hello World!" message for now, so we're not making use of any of the content of the request. What's nice about this is that it lets us write a pretty static HTTP response message here and show off that there's no magic going on, its just simple text.