### PR TITLE
3. Parsing HTTP requests

### DIFF
--- a/web_server.rb
+++ b/web_server.rb
@@ -9,6 +9,44 @@ class WebServer
     @server = TCPServer.new HOST, PORT
   end
 
+  # We'll convert the raw HTTP string into a series of lines
+  # The first line will be considered the "Request Line" which
+  # includes the method (eg. GET/POST), path, and HTTP version.
+  #
+  # Next comes the (optional) header lines with the key and value
+  # separated by a colon.
+  #
+  # After the headers, there comes a single blank line as a delimeter.
+  # In our parsing function, we use the presence of that line to find
+  # the end of our headers, and the start of our body.
+  #
+  # After that, comes the body of the message itself.
+  def parse_request(request_http)
+    lines = request_http.split("\n")
+
+    request_line = lines.shift
+    method, path, version = request_line.split
+
+    headers = {}
+    loop do
+      line = lines.shift
+      break if line =~ /^\s*$/
+
+      key, value = line.split(':', 2)
+      headers[key] = value.strip
+    end
+
+    body = lines.join("\n")
+
+    {
+      'method' => method,
+      'path' => path,
+      'version' => version,
+      'headers' => headers,
+      'body' => body,
+    }
+  end
+
   # Our response must comply with the HTTP Spec
   # https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html
   #
@@ -25,11 +63,11 @@ class WebServer
   # Most browsers will simply print this body out if it is text,
   # which is what we use in this example. HTML and other formats can
   # also be used here by setting the appropriate Content-Type header.
-  def response
-    response_body = 'Hello World!'
+  def prepare_response(request)
+    response_body = "Hello World!\n#{request}"
     <<~EOF
       HTTP/1.1 200 OK
-      Content-Type: text/html
+      Content-Type: text/plain
       Content-Length: #{response_body.length}
 
       #{response_body}
@@ -42,9 +80,10 @@ class WebServer
 
     loop do
       connection = @server.accept
-      request = connection.recv MAX_REQUEST_SIZE
+      request_http = connection.recv MAX_REQUEST_SIZE
+      request = parse_request(request_http)
       puts request
-      connection.puts response
+      connection.puts prepare_response(request)
       connection.close
     end
   end


### PR DESCRIPTION
Similarly to our last step where we introduced the formatting of HTTP responses, this step requires us to understand the formatting of HTTP requests. We'll refer to the [HTTP spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html) once again for the format of an HTTP request, which looks pretty similar:

```
        Request       = Request-Line
                        *(( general-header
                         | request-header
                         | entity-header ) CRLF)
                        CRLF
                        [ message-body ]

        Request-Line   = Method SP Request-URI SP HTTP-Version CRLF
```

We build a (very naive) parser that assumes that the browser has sent us a valid HTTP request and we break it down into its component parts. We store those in hash which we'll call a request, and we'll differentiate that from our previous "request" variable by renaming that one to "http_request". This allows us to differentiate between the raw string that we received, and the structured hash that we've turned it into.

Also note that we've changed the content type from "text/html" to "text/plain". Since we're now putting user-generated content into the body, we want to make sure that the user can't sneak something malicious in there and have it be evaluated as html or javascript. This text/plain content type will tell the browser to just treat this as plain old text.

We're really starting to develop a web server now! Try visiting a couple of different urls on this server like http://127.0.0.1/whatever and you will see it reflected in the message that gets printed to the browser.

Next up, we will want to start "doing something" based on which path was requested.